### PR TITLE
Ability to track more than one URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+venv/
+config.json
+database.db

--- a/config_gui.py
+++ b/config_gui.py
@@ -10,7 +10,23 @@ def cancelclick():
 
 class GUI:
     def okclick(self):
-        data = {"url": self.urlentry.get(),
+
+        urls = []
+        urls_text = self.urlentry.get("1.0", "end-1c")
+        urls_lines = urls_text.split("\n")
+
+        for url_line in urls_lines:
+            if not url_line or len(url_line) < 2:
+                break
+
+            url_line = url_line.split(" ")
+
+            url_name = url_line[0] if len(url_line) > 1 else None
+            url_url = url_line[1] if url_name else url_line[0]
+
+            urls.append({"name": url_name, "url": url_url})
+
+        data = {"urls": urls,
                 "telegramAPIKEY": self.apikeyentry.get(),
                 "telegramCHATID": self.chatidentry.get(),
                 "databaseFile": self.databaseentry.get(),
@@ -25,10 +41,12 @@ class GUI:
     def __init__(self, file_name):
         self.file_name = file_name
         self.window = tk.Tk()
-        self.window.geometry('605x300')
+        self.window.geometry('706x550')
 
-        urllabel = tk.Label(text="url")
-        self.urlentry = tk.Entry(width=100, justify=tk.CENTER)
+        urllabel = tk.Label(text="urls (one per line)")
+        urlscroll = tk.Scrollbar(self.window, orient=tk.VERTICAL)
+        self.urlentry = tk.Text(width=100, height=16)
+        self.urlentry.configure(yscrollcommand=urlscroll.set)
 
         databaselabel = tk.Label(text="databaseFile")
         self.databaseentry = tk.Entry(width=100, justify="center")
@@ -66,7 +84,18 @@ class GUI:
         if os.path.isfile(file_name):
             with open(file_name) as config_file:
                 config = json.load(config_file)
-                self.urlentry.insert(0, config["url"])
+
+                # Get array of urls to scrape or fallback to single url
+                urls = config.get("urls")
+                if not urls:
+                    url = config["url"]
+                    urls = [{"url": url}]
+                
+                url_text = ""
+                for url in urls:
+                    url_text += f'{url["name"] if "name" in url else ""} {url["url"]}' + "\n"
+                self.urlentry.insert(tk.END, url_text)
+
                 self.apikeyentry.insert(0, config["telegramAPIKEY"])
                 self.chatidentry.insert(0, config["telegramCHATID"])
                 self.databaseentry.insert(0, config["databaseFile"])

--- a/config_gui.py
+++ b/config_gui.py
@@ -19,7 +19,7 @@ class GUI:
             if not url_line or len(url_line) < 2:
                 break
 
-            url_line = url_line.split(" ")
+            url_line = url_line.strip().split(" ")
 
             url_name = url_line[0] if len(url_line) > 1 else None
             url_url = url_line[1] if url_name else url_line[0]
@@ -93,7 +93,7 @@ class GUI:
                 
                 url_text = ""
                 for url in urls:
-                    url_text += f'{url["name"] if "name" in url else ""} {url["url"]}' + "\n"
+                    url_text += f'{(url["name"] + " ") if "name" in url else ""}{url["url"]}' + "\n"
                 self.urlentry.insert(tk.END, url_text)
 
                 self.apikeyentry.insert(0, config["telegramAPIKEY"])

--- a/scraper.py
+++ b/scraper.py
@@ -48,7 +48,7 @@ def sql_connection(file_name):
         print(Error)
 
 
-def scraper(urls, apikey, chatid, sleep):
+def scraper(urls, apikey, chatid, sleep, print_names=False):
     global con
     cursordb = con.cursor()
 
@@ -59,7 +59,7 @@ def scraper(urls, apikey, chatid, sleep):
             url = url_item.get("url")
             name = url_item.get("name")
 
-            if name:
+            if print_names and name:
                 print(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] Scraping for {name}")
 
             # Load and parse the html from supplied ebay search page
@@ -130,7 +130,7 @@ def scraper(urls, apikey, chatid, sleep):
         time.sleep(int(sleep))
 
 
-def startup(filename_path):
+def startup(filename_path, print_names=False):
     global con
     # Obtain parameters from the json file
     # User must specify the file path as an argument when running this script
@@ -160,12 +160,13 @@ def startup(filename_path):
     signal(SIGINT, exit_handler)
 
     # Start the scraper
-    scraper(urls, apikey, chatid, sleep)
+    scraper(urls, apikey, chatid, sleep, print_names)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-nogui", "--nogui", action="store_true")
+    parser.add_argument("-printnames", "--printnames", action="store_true")
     parser.add_argument("-path", metavar="--path",
                         type=str,
                         default="config.json",
@@ -180,7 +181,7 @@ if __name__ == '__main__':
     # There must be a better way
     while True:
         try:
-            startup(filename)
+            startup(filename, options.printnames or False)
         except Exception as e:
             print(e)
             print("Restarting the application in " + str(RESTART_TIME) + " seconds")

--- a/scraper.py
+++ b/scraper.py
@@ -116,7 +116,7 @@ def scraper(urls, apikey, chatid, sleep):
                         try:
                             sendTelegram("https://" + urlparse(
                                 url).netloc + "/itm/" + prodstr[
-                                            0] + "\n" + prodstr[1], chatid, apikey)
+                                            0] + "\n" + prodstr[1] + (f"\n{name}") if name else "", chatid, apikey)
                             # Telegram API limits the number of messages per second so we need to wait a little bit
                             time.sleep(0.5)
                         except Exception:

--- a/scraper.py
+++ b/scraper.py
@@ -54,6 +54,7 @@ def scraper(urls, apikey, chatid, sleep):
 
     # Infinite loop, safe way to close the program is to send a SIGINT signal (CTRL-C)
     while True:
+        # Loop over every URL to scrape
         for url_item in urls:
             url = url_item.get("url")
             name = url_item.get("name")
@@ -136,6 +137,7 @@ def startup(filename_path):
     with open(filename_path) as config_file:
         config = json.load(config_file)
 
+        # Get array of urls to scrape or fallback to single url
         urls = config.get("urls")
         if not urls:
             url = config["url"]


### PR DESCRIPTION
This allows to track multiple URLs with a single scraper instance.
It is also possible to give a name to every search URL, if specified it will be printed on the console and sent in the Telegram message.

The GUI configuration part is ugly, but I don't have much experience with Tk.

Backwards compatible with older config (single URL).
The GUI will convert the old single URL format to the new multiple URLs format.

Example config.json
```
{
  "urls": [
    {
      "name": "console",
      "url": "https://www.ebay.it/sch/i.html?_from=R40&_nkw=console&_sacat=0&LH_ItemCondition=7000&_sop=10&rt=nc&LH_PrefLoc=3"
    },
    {
      "name": "nintendo_switch",
      "url": "https://www.ebay.it/sch/i.html?_from=R40&_nkw=nintendo+switch&_sacat=0&LH_ItemCondition=7000&_sop=10&rt=nc&LH_PrefLoc=3"
    },
    {
      "name": "ps4",
      "url": "https://www.ebay.it/sch/i.html?_from=R40&_nkw=ps4&_sacat=0&_sop=10&LH_ItemCondition=7000&rt=nc&LH_PrefLoc=3"
    },
    {
      "name": "ps5",
      "url": "https://www.ebay.it/sch/i.html?_from=R40&_nkw=ps5&_sacat=0&_sop=10&LH_ItemCondition=7000&rt=nc&LH_PrefLoc=3"
    }
  ],
  "telegramAPIKEY": "***",
  "telegramCHATID": "***",
  "databaseFile": "database.db",
  "sleep": "300"
}
```